### PR TITLE
feat: CartItem to manage removedItems. Add proper Cart implementation

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -5,15 +5,16 @@ import Reservation from "./models/Reservation.mjs";
 import Cart from "./models/Cart.mjs";
 import Reservations from "./models/Reservations.mjs";
 import BagItem from "./models/BagItem.mjs";
+import CartItem from "./models/CartItem.mjs";
 import assert from "node:assert/strict";
 
 
 //Example to test the models
 const user1 = new User(1, "mail@esempio.com", "Forza", "Toro", ["peanuts"]);
 
-const bag1 = new Bag(1, "regular", 101, 5, "2025-03-13 10:00:00", "2025-03-14 12:00:00");
-bag1.addItem(new BagItem(1, "Sandwich", 1, 1));
-bag1.addItem(new BagItem(2, "Apple", 1, 1));
+const bag1 = new Bag(1, Bag.TYPE_REGULAR, 101, 5, "2025-03-13 10:00:00", "2025-03-14 12:00:00");
+bag1.addItem(new BagItem(1, 1, "Sandwich", 1));
+bag1.addItem(new BagItem(1, 2, "Apple", 1));
 assert.equal(bag1.items.length, 2);
 
 const est1 = new Establishment(101, "Bakery", [bag1], "store");
@@ -24,3 +25,72 @@ const reservations = new Reservations();
 reservations.add(reservation1);
 
 console.log("User Reservations:", reservations.getByUser(user1.id));
+
+// Cart Tests
+console.log("\n---- CART TESTS ----");
+est1.bags = [bag1]; // Add bag1 to establishment 101
+
+// Create a second bag for testing
+const bag2 = new Bag(2, Bag.TYPE_REGULAR, 102, 10, "2025-03-13 14:00:00", "2025-03-14 16:00:00");
+bag2.addItem(new BagItem(2, 3, "Chocolate Bar", 2));
+const est2 = new Establishment(102, "Coffee Shop", [bag2], "store");
+est2.bags = [bag2]; // Add bag2 to establishment 102
+
+
+// Test cart creation
+const cart = new Cart(user1.id);
+assert.equal(cart.items.length, 0, "Cart should start empty");
+console.log("Cart creation test: PASSED");
+
+// Test adding items to cart
+const cartItem1 = cart.addItem(new CartItem(bag1));
+assert.equal(cart.items.length, 1, "Cart should have 1 item");
+assert.equal(cartItem1.bag, bag1, "Cart item should reference the correct bag");
+assert.equal(cartItem1.removedItems.length, 0, "Cart item should have no removed items initially");
+console.log("Adding item to cart test: PASSED");
+
+// Test adding a second bag
+const removedItems = [1]; // Remove item with ID 1 (Sandwich)
+const cartItem2 = cart.addItem(new CartItem(bag2, removedItems));
+
+assert.equal(cart.items.length, 2, "Cart should have 2 items");
+assert.equal(cartItem2.bag, bag2, "Second cart item should reference the correct bag");
+assert.equal(cartItem2.removedItems.length, 1, "Second cart item should have 1 removed item");
+console.log("Adding personalized item to cart test: PASSED");
+
+// Test one bag per establishment per day constraint
+try {
+    // Create a third bag from the same establishment as bag1 (est1)
+    const bag3 = new Bag(3, "regular", 101, 7, "2025-03-13 16:00:00", "2025-03-14 18:00:00");
+    cart.addItem(new CartItem(bag3));
+    assert.fail("Should not allow adding a second bag from the same establishment on the same day");
+} catch (error) {
+    assert.equal(error.message, "One bag per establishment per day", "Should throw correct error message");
+    console.log("One bag per establishment per day constraint test: PASSED");
+}
+
+// Test CartItem functionality - removing items
+const newBag = new Bag(4, "regular", 103, 8, "2025-03-15 10:00:00", "2025-03-15 12:00:00");
+newBag.addItem(new BagItem(4, 5, "Salad", 1));
+newBag.addItem(new BagItem(4, 6, "Fruit", 1));
+newBag.addItem(new BagItem(4, 7, "Dessert", 1));
+
+const cartItem = new CartItem(newBag);
+assert.equal(cartItem.removedItems.length, 0, "CartItem should start with no removed items");
+
+cartItem.removeItem(5); // Remove the salad
+assert.equal(cartItem.removedItems.length, 1, "CartItem should have 1 removed item");
+assert.equal(cartItem.removedItems[0], 5, "Removed item ID should match");
+
+cartItem.removeItem(6); // Remove the fruit
+assert.equal(cartItem.removedItems.length, 2, "CartItem should have 2 removed items");
+
+try {
+    cartItem.removeItem(7); // Try to remove a third item - should throw an error
+    assert.fail("Should not allow removing more than 2 items from a regular bag");
+} catch (error) {
+    console.log("CartItem removeItem test: PASSED");
+}
+
+console.log("CartItem removeItem test: PASSED");
+console.log("All Cart tests passed!");

--- a/src/models/Bag.mjs
+++ b/src/models/Bag.mjs
@@ -1,10 +1,8 @@
 import dayjs from 'dayjs';
 
-
+/** A Bag is managed by an establishment. 
+ * It can be reserved by a single user at a time */ 
 class Bag {
-    static STATUS_NOT_TAKEN = "not taken";
-    static STATUS_TAKEN = "taken";
-
     static TYPE_SURPRISE = "surprise";
     static TYPE_REGULAR = "regular";
 
@@ -18,18 +16,18 @@ class Bag {
      * @param {number} price - The price of the bag.
      * @param {string} pickupTimeStart - The start time for pickup in ISO 8601 format.
      * @param {string} pickupTimeEnd - The end time for pickup in ISO 8601 format.
-     * @param {string} [status=Bag.STATUS_NOT_TAKEN] - The status of the bag.
      * @param {Array} items - The items in the bag.
      */
-    constructor(id, bagType, estId, price, pickupTimeStart, pickupTimeEnd, status=Bag.STATUS_NOT_TAKEN) {
+    constructor(id, bagType, estId, price, pickupTimeStart, pickupTimeEnd) {
         this.id = id;
         this.bagType = bagType;
         this.estId = estId;
         this.price = price; 
-        this.status = status;
         this.items = [];
-        this.pickupTimeStart = dayjs(pickupTimeStart).format('YYYY-MM-DD HH:mm:ss');
-        this.pickupTimeEnd = dayjs(pickupTimeEnd).format('YYYY-MM-DD HH:mm:ss');
+        this.pickupTimeStart = dayjs(pickupTimeStart);
+        this.pickupTimeEnd = dayjs(pickupTimeEnd);
+
+        this.reservedBy = null;
     }
 
 
@@ -47,34 +45,17 @@ class Bag {
         return false;
     }
 
-
-    removeItem(item){
-        //Returns true if success, otherwise false
-
-        itemId = item.id;
-
-        if (this.bagType.toLowerCase === "regular"){
-            if (this.removedItems.length >= 2) {
-                console.log("Maximum limit of removable items exceeded");
-                return false;
-            }
-
-            //retrieve the index of the items to be removed
-
-            const idx = this.bagItems.findIndex(x => x.id === itemId);
-
-            if (idx == -1){
-                console.log("Item not found");
-                return false;
-            } 
-
-            this.items.splice(idx, 1)[0];
-            return true;
-        } else {
-            console.log("Bag type must be regular to remove items from the bag")
-            return false;
+    setReservedBy(userId){
+        if (this.reservedBy != null){
+            throw new Error("Bag already reserved");
         }
-
+        this.reservedBy = userId;
+    }
+    getReservedBy() {
+        return this.reservedBy;
+    }
+    isReserved() {
+        return this.reservedBy !== null;
     }
 }
 

--- a/src/models/BagItem.mjs
+++ b/src/models/BagItem.mjs
@@ -1,9 +1,15 @@
 class BagItem {
-     constructor(id, name, quantity, bagId) {
+    /**
+     * @param {number} bagId
+     * @param {number} id - Unique id for the item. Unique within the bag.
+     * @param {string} name
+     * @param {number} quantity - Must always be greater than 0.
+     */
+    constructor(bagId, id, name, quantity) {
+        this.bagId = bagId;
         this.id = id;
         this.name = name;
         this.quantity = quantity;
-        this.bagId = bagId;
     }
 }
 

--- a/src/models/Cart.mjs
+++ b/src/models/Cart.mjs
@@ -1,12 +1,32 @@
+import CartItem from "./CartItem.mjs";
+
+/** A class may contain multiple personalized bags, CartItems.
+ * No more than one bag per establishment per day can be added to the cart. */
 class Cart {
-    constructor(id, userId, listBag) {
-        this.id = id;
+    constructor(userId) {
         this.userId = userId;
-        this.listBag = listBag;
+        this.items = [];
     }
 
-    totPrice() {
-        return this.listBag.reduce((acc, bag) => acc + (bag.price || 0), 0);
+    /**
+     * Adds an item to the cart.
+     * 
+     * @param {CartItem} item - The item to be added to the cart.
+     * @throws {Error} Throws an error if there is already a bag from the same establishment on the same day.
+     * @returns {CartItem} The newly added item.
+     */
+    addItem(cartItem) {
+        // Validate establishment/day constraint
+        const existing = this.items.find(item =>
+            item.bag.estId === cartItem.bag.estId && 
+            item.bag.pickupTimeStart.isSame(cartItem.bag.pickupTimeStart, 'day')
+        );
+
+        if (existing) throw new Error('One bag per establishment per day');
+
+
+        this.items.push(cartItem);
+        return cartItem;
     }
 }
 

--- a/src/models/CartItem.mjs
+++ b/src/models/CartItem.mjs
@@ -1,0 +1,46 @@
+import Bag from "./Bag.mjs";
+import dayjs from 'dayjs';
+
+/** A CartItem is a bag added to a cart. It can be personalized by the user, 
+ * who can remove some items from the bag or add special requests.
+ * A special request can be "no peanuts" or "no animal products (vegan)", for example.
+ * Multiple CartItems can contain the same bag, but with different user personalizations.
+ */
+class CartItem {
+    /**
+     * Creates an instance of CartItem.
+     * 
+     * @constructor
+     * @param {Object} bag - The bag object containing items.
+     * @param {Array<string>} [removedItems=[]] - An array of item IDs to be removed from the bag.
+     */
+    constructor(bag, removedItems = []) {
+        this.bag = bag;
+
+        this.removedItems = [];
+        for (let item of removedItems) {
+            this.removeItem(item);
+        }
+
+        this.addedAt = dayjs(); // Track cart addition time
+    }
+
+    /**
+     * Adds an item to the list of removed items.
+     * Only 2 items can be removed from a regular bag.
+     * No items can be removed from a surprise bag.
+     * 
+     * @param {string} itemId - The ID of the item to be removed.
+     * @throws {Error} Throws an error if the bag is not of type regular or removedItems >= 2.
+     * @returns {void}
+     */
+    removeItem(itemId) {
+        if (this.bag.bagType !== Bag.TYPE_REGULAR || this.removedItems.length >= 2)
+            throw new Error('Cannot remove more items');
+        if (this.bag.items.some(item => item.itemId === itemId)) return;
+
+        this.removedItems = [...new Set([...this.removedItems, itemId])];
+    }
+}
+
+export default CartItem;

--- a/src/models/Reservation.mjs
+++ b/src/models/Reservation.mjs
@@ -1,11 +1,44 @@
 import dayjs from 'dayjs';
+import Bag from './Bag.mjs';
 
 class Reservation {
-    constructor(id, userId, estId, createdAt) {
+    constructor(id, user, cartItems) {
         this.id = id;
-        this.userId = userId;
-        this.estId = estId;
-        this.createdAt = dayjs(createdAt).format('YYYY-MM-DD HH:mm:ss');
+        this.user = user;
+        this.createdAt = dayjs().toDate();
+        this.cartItems = cartItems;
+        this.canceledAt = null;
+    }
+
+    validateCartItems(items) {
+        // Check pickup times are in future
+        items.forEach(item => {
+            if (item.bag.pickupStartItem <= this.createdAt) {
+                throw new Error('Cannot reserve expired bags');
+            }
+        });
+        return items;
+    }
+
+    confirm() {
+        // This flow must be converted for the database
+        if (this.cartItems.every(item => !item.bag.isReserved())) {
+            this.cartItems.forEach(item => {
+                item.bag.setReservedBy(this.user.id); // Track reserving user
+            });
+            return true;
+        }
+        return false;
+    }
+
+    cancel() {
+        const now = dayjs();
+        this.canceledAt = now;
+        this.cartItems.forEach(item => {
+            if (item.bag.pickupStart > now) {
+                item.bag.setReservedBy(null);
+            }
+        });
     }
 }
 

--- a/src/models/Reservations.mjs
+++ b/src/models/Reservations.mjs
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import Reservation from './Reservation.mjs';
 
 class Reservations {
     constructor() {
@@ -31,6 +32,10 @@ class Reservations {
 
     getEndAt_ByDay(day) {
         return this.list.filter(res => dayjs(res.endAt).isSame(day, 'day'));
+    }
+
+    validateOneBagPerEstablishmentPerDay(userId, bag) {
+        // TODO: Implement this method, or maybe enforce the invariant at the database level?
     }
 }
 


### PR DESCRIPTION
`CartItem` is needed to manage users concurrently adding a bag to their cart and removing items.
 
 A proper implementation for `Cart` is added, to respect the requirements of keeping a single reservation per establishment per day